### PR TITLE
Remove ScanID from ScanInfo since it's not used

### DIFF
--- a/pkg/handlers/v1/nexposevulnnotifier.go
+++ b/pkg/handlers/v1/nexposevulnnotifier.go
@@ -7,10 +7,8 @@ import (
 	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/logs"
 )
 
-// ScanInfo represents the incoming payload
+// ScanInfo represents the fields we want from the incoming payload
 type ScanInfo struct {
-	// ScanID is the ID of the completed scan whose vulnerabilities we'll process
-	ScanID string `json:"scan_id"`
 	// SiteID is the ID of the site that just got scanned
 	SiteID string `json:"site_id"`
 }


### PR DESCRIPTION
I initially added the ScanID here because I thought I would need to provide it to the Nexpose API in order to get the assets from the last scan, but it wasn't required since Nexpose scans entire sites at a time, so I could get all the assets by just using the SiteID. This can be confusing and misleading to the reader, so I'm removing it from the struct, but leaving it in the api.yml since that's that Splunk will send us and in case we want to make use of it later.