### PR TITLE
Secd 529/trim nexpose payload

### DIFF
--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -1,7 +1,10 @@
-package domain
+package assetfetcher
 
 import (
 	"os"
+	"time"
+
+	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/domain"
 )
 
 // Asset represents a Nexpose asset response payload
@@ -20,7 +23,7 @@ type Asset struct {
 	// The files discovered with searching on the asset.
 	Files []*os.File `json:"files,omitempty"`
 	// The history of changes to the asset over time.
-	History []AssetHistory `json:"history,omitempty"`
+	History assetHistoryEvents `json:"history,omitempty"`
 	// The primary host name (local or FQDN) of the asset.
 	HostName string `json:"hostName,omitempty"`
 	// All host names or aliases discovered on the asset.
@@ -285,4 +288,37 @@ type VulnerabilitySummary struct {
 	Severe int64 `json:"severe,omitempty"`
 	// The total number of vulnerabilities.
 	Total int64 `json:"total,omitempty"`
+}
+
+// AssetPayloadToAssetEvent translates a Nexpose Asset API response payload
+// into an AssetEvent for downstream services
+func (a Asset) AssetPayloadToAssetEvent() (domain.AssetEvent, error) {
+	lastScanned, err := a.History.lastScannedTimestamp()
+	if err != nil {
+		return domain.AssetEvent{}, err
+	}
+	return domain.AssetEvent{
+		ID:          a.ID,
+		Hostname:    a.HostName,
+		IP:          a.IP,
+		LastScanned: lastScanned,
+	}, nil
+}
+
+type assetHistoryEvents []AssetHistory
+
+func (a assetHistoryEvents) lastScannedTimestamp() (time.Time, error) {
+	latestTime := time.Time{}
+	for _, evt := range a {
+		if evt.Type == "SCAN" {
+			t, err := time.Parse(time.RFC3339, evt.Date)
+			if err != nil {
+				return latestTime, err
+			}
+			if t.After(latestTime) {
+				latestTime = t
+			}
+		}
+	}
+	return latestTime, nil
 }

--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -1,7 +1,6 @@
 package assetfetcher
 
 import (
-	"os"
 	"time"
 
 	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/domain"
@@ -21,7 +20,7 @@ type Asset struct {
 	// The databases enumerated on the asset.
 	Databases []Database `json:"databases,omitempty"`
 	// The files discovered with searching on the asset.
-	Files []*os.File `json:"files,omitempty"`
+	Files []File `json:"files,omitempty"`
 	// The history of changes to the asset over time.
 	History assetHistoryEvents `json:"history,omitempty"`
 	// The primary host name (local or FQDN) of the asset.
@@ -84,6 +83,26 @@ type Database struct {
 	ID int32 `json:"id,omitempty"`
 	// The name of the database instance.
 	Name string `json:"name"`
+}
+
+// File discovered with searching on the asset.
+type File struct {
+	// Attributes detected on the file.
+	Attributes []Attribute `json:"attributes,omitempty"`
+	// The name of the file
+	Name string `json:"name,omitempty"`
+	// The size of the regular file (in bytes). If the file is a directory, no value is returned.
+	Size int64 `json:"size,omitempty"`
+	// The type of the file.
+	Type string `json:"type,omitempty"`
+}
+
+// Attribute detected on the file.
+type Attribute struct {
+	// The name of the configuration value.
+	Name string `json:"name"`
+	// The configuration value.
+	Value string `json:"value"`
 }
 
 // AssetHistory represents a change to the asset

--- a/pkg/assetfetcher/asset_test.go
+++ b/pkg/assetfetcher/asset_test.go
@@ -1,0 +1,58 @@
+package assetfetcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLastAssessedForVulnerabilities(t *testing.T) {
+	tests := []struct {
+		name        string
+		history     assetHistoryEvents
+		expected    time.Time
+		expectedErr bool
+	}{
+		{
+			"single event",
+			assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}},
+			time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
+			false,
+		},
+		{
+			"multiple events in chronological order",
+			assetHistoryEvents{
+				AssetHistory{Type: "SCAN", Date: "2018-04-22T15:02:44.000Z"},
+				AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"},
+			},
+			time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
+			false,
+		},
+		{
+			"multiple events in non-chronological order",
+			assetHistoryEvents{
+				AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"},
+				AssetHistory{Type: "SCAN", Date: "2018-04-22T15:02:44.000Z"},
+			},
+			time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
+			false,
+		},
+		{
+			"invalid date",
+			assetHistoryEvents{
+				AssetHistory{Type: "SCAN", Date: "iamnotadate"},
+			},
+			time.Time{},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			lastAssessed, err := test.history.lastScannedTimestamp()
+			assert.Equal(t, test.expected, lastAssessed)
+			assert.Equal(t, test.expectedErr, err != nil)
+		})
+	}
+
+}

--- a/pkg/assetfetcher/errors.go
+++ b/pkg/assetfetcher/errors.go
@@ -55,3 +55,15 @@ type ErrorFetchingAssets struct {
 func (e *ErrorFetchingAssets) Error() string {
 	return fmt.Sprintf("Error fetching assets from Nexpose %v", e.Inner)
 }
+
+// ErrorConvertingAssetPayload represents an error we get when trying to convert a Nexpose Asset
+// payload to AssetEvent
+type ErrorConvertingAssetPayload struct {
+	AssetID int64
+	Inner   error
+}
+
+// Error returns an ErrorConvertingAssetPayload
+func (e *ErrorConvertingAssetPayload) Error() string {
+	return fmt.Sprintf("Error converting asset %v payload to event %v", e.AssetID, e.Inner)
+}

--- a/pkg/assetfetcher/errors_test.go
+++ b/pkg/assetfetcher/errors_test.go
@@ -44,6 +44,11 @@ func TestAssetFetcherErrors(t *testing.T) {
 			&ErrorFetchingAssets{customError},
 			fmt.Sprintf("Error fetching assets from Nexpose %v", customError),
 		},
+		{
+			"ErrorConvertingAssetPayload",
+			&ErrorConvertingAssetPayload{123456, customError},
+			fmt.Sprintf("Error converting asset 123456 payload to event %v", customError),
+		},
 	}
 
 	for _, tt := range tc {
@@ -81,6 +86,10 @@ func TestAssetFetcherErrorsCanBeNil(t *testing.T) {
 		{
 			"ErrorFetchingAssets",
 			&ErrorFetchingAssets{},
+		},
+		{
+			"ErrorConvertingAssetPayload",
+			&ErrorConvertingAssetPayload{},
 		},
 	}
 

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -20,12 +20,12 @@ func TestFetchAssetsSuccess(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 
-	expectedAsset := domain.Asset{
+	expectedAsset := domain.AssetEvent{
 		IP: "127.0.0.1",
 		ID: 123456,
 	}
 	resp := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset},
+		Resources: []Asset{Asset{IP: "127.0.0.1", ID: 123456}},
 		Page: Page{
 			TotalPages:     1,
 			TotalResources: 1,
@@ -46,7 +46,7 @@ func TestFetchAssetsSuccess(t *testing.T) {
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	var actualAsset domain.Asset
+	var actualAsset domain.AssetEvent
 	for {
 		select {
 		case respAsset, ok := <-assetChan:
@@ -74,11 +74,11 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 
-	expectedAsset1 := domain.Asset{
+	expectedAsset1 := domain.AssetEvent{
 		IP: "127.0.0.1",
 		ID: 123,
 	}
-	expectedAsset2 := domain.Asset{
+	expectedAsset2 := domain.AssetEvent{
 		IP: "127.0.0.2",
 		ID: 456,
 	}
@@ -87,11 +87,11 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 		TotalResources: 2,
 	}
 	resp1 := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset1},
+		Resources: []Asset{Asset{IP: "127.0.0.1", ID: 123}},
 		Page:      page,
 	}
 	resp2 := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset2},
+		Resources: []Asset{Asset{IP: "127.0.0.2", ID: 456}},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(resp1)
@@ -114,7 +114,7 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	var assets []domain.Asset
+	var assets []domain.AssetEvent
 	for {
 		select {
 		case respAsset, ok := <-assetChan:
@@ -135,7 +135,7 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, []domain.Asset{expectedAsset1, expectedAsset2}, assets)
+	assert.Equal(t, []domain.AssetEvent{expectedAsset1, expectedAsset2}, assets)
 }
 
 func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
@@ -143,25 +143,25 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 
-	expectedAsset1 := domain.Asset{ID: 1}
-	expectedAsset2 := domain.Asset{ID: 2}
-	expectedAsset3 := domain.Asset{ID: 3}
-	expectedAsset4 := domain.Asset{ID: 4}
-	expectedAsset5 := domain.Asset{ID: 5}
+	expectedAsset1 := domain.AssetEvent{ID: 1}
+	expectedAsset2 := domain.AssetEvent{ID: 2}
+	expectedAsset3 := domain.AssetEvent{ID: 3}
+	expectedAsset4 := domain.AssetEvent{ID: 4}
+	expectedAsset5 := domain.AssetEvent{ID: 5}
 	page := Page{
 		TotalPages:     3,
 		TotalResources: 5,
 	}
 	page1Resp := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset1, expectedAsset2},
+		Resources: []Asset{Asset{ID: 1}, Asset{ID: 2}},
 		Page:      page,
 	}
 	page2Resp := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset3, expectedAsset4},
+		Resources: []Asset{Asset{ID: 3}, Asset{ID: 4}},
 		Page:      page,
 	}
 	page3Resp := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset5},
+		Resources: []Asset{Asset{ID: 5}},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(page1Resp)
@@ -189,7 +189,7 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	var assets []domain.Asset
+	var assets []domain.AssetEvent
 	for {
 		select {
 		case respAsset, ok := <-assetChan:
@@ -223,19 +223,19 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalledWithError(t *testing.T)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 
-	expectedAsset1 := domain.Asset{ID: 1}
-	expectedAsset2 := domain.Asset{ID: 2}
-	expectedAsset3 := domain.Asset{ID: 3}
+	expectedAsset1 := domain.AssetEvent{ID: 1}
+	expectedAsset2 := domain.AssetEvent{ID: 2}
+	expectedAsset3 := domain.AssetEvent{ID: 3}
 	page := Page{
 		TotalPages:     3,
 		TotalResources: 5,
 	}
 	page1Resp := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset1, expectedAsset2},
+		Resources: []Asset{Asset{ID: 1}, Asset{ID: 2}},
 		Page:      page,
 	}
 	page3Resp := SiteAssetsResponse{
-		Resources: []domain.Asset{expectedAsset3},
+		Resources: []Asset{Asset{ID: 3}},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(page1Resp)
@@ -261,7 +261,7 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalledWithError(t *testing.T)
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	var assets []domain.Asset
+	var assets []domain.AssetEvent
 	var retErrors []error
 	for {
 		select {
@@ -366,12 +366,12 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 	mockRT := NewMockRoundTripper(ctrl)
 
 	resp := SiteAssetsResponse{
-		Resources: []domain.Asset{},
+		Resources: []Asset{},
 		Page: Page{
 			TotalPages:     1,
 			TotalResources: 1,
 		},
-		Links: domain.Link{},
+		Links: Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 
@@ -387,7 +387,7 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	assert.Equal(t, domain.Asset{}, <-assetChan) // An empty asset will be added to assetChan if there's a response with no asset
+	assert.Equal(t, domain.AssetEvent{}, <-assetChan) // An empty asset will be added to assetChan if there's a response with no asset
 	assert.Nil(t, <-errChan)
 }
 
@@ -430,18 +430,69 @@ func TestFetchAssetsHTTPError(t *testing.T) {
 	assert.IsType(t, &NexposeHTTPRequestError{}, actualError)
 }
 
+func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRT := NewMockRoundTripper(ctrl)
+
+	resp := SiteAssetsResponse{
+		Resources: []Asset{Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Page: Page{
+			TotalPages:     1,
+			TotalResources: 1,
+		},
+		Links: Link{},
+	}
+	respJSON, _ := json.Marshal(resp)
+	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+		Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	nexposeAssetFetcher := &NexposeAssetFetcher{
+		HTTPClient: &http.Client{Transport: mockRT},
+		Host:       "http://localhost",
+		PageSize:   1,
+	}
+
+	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
+
+	var actualError error
+
+	for {
+		select {
+		case respAsset, ok := <-assetChan:
+			if !ok {
+				assetChan = nil
+			} else {
+				t.Fatalf("Unexpected error occurred %v ", respAsset)
+			}
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil
+			} else {
+				actualError = err
+			}
+		}
+		if assetChan == nil && errChan == nil {
+			break
+		}
+	}
+	assert.IsType(t, &ErrorConvertingAssetPayload{}, actualError)
+}
+
 func TestFetchAssetsWithInvalidHost(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
-	asset := domain.Asset{
+	asset := Asset{
 		IP: "127.0.0.1",
 		ID: 123456,
 	}
 	resp := SiteAssetsResponse{
-		Resources: []domain.Asset{asset},
+		Resources: []Asset{asset},
 		Page:      Page{},
-		Links:     domain.Link{},
+		Links:     Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -486,14 +537,14 @@ func TestMakeRequestSuccess(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 
-	asset := domain.Asset{
+	asset := Asset{
 		IP: "127.0.0.1",
 		ID: 123456,
 	}
 	resp := SiteAssetsResponse{
-		Resources: []domain.Asset{asset},
+		Resources: []Asset{asset},
 		Page:      Page{},
-		Links:     domain.Link{},
+		Links:     Link{},
 	}
 
 	respJSON, _ := json.Marshal(resp)
@@ -509,7 +560,7 @@ func TestMakeRequestSuccess(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	assetChan := make(chan domain.Asset, 1)
+	assetChan := make(chan domain.AssetEvent, 1)
 	errChan := make(chan error, 1)
 	defer close(assetChan)
 	defer close(errChan)
@@ -538,7 +589,7 @@ func TestMakeRequestWithErrorReadingResponse(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	assetChan := make(chan domain.Asset, 1)
+	assetChan := make(chan domain.AssetEvent, 1)
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
@@ -556,9 +607,9 @@ func TestMakeRequestWithInvalidHost(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 	resp := SiteAssetsResponse{
-		Resources: []domain.Asset{},
+		Resources: []Asset{},
 		Page:      Page{},
-		Links:     domain.Link{},
+		Links:     Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -573,7 +624,7 @@ func TestMakeRequestWithInvalidHost(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	assetChan := make(chan domain.Asset, 1)
+	assetChan := make(chan domain.AssetEvent, 1)
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
@@ -600,7 +651,7 @@ func TestMakeRequestHTTPError(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	assetChan := make(chan domain.Asset, 1)
+	assetChan := make(chan domain.AssetEvent, 1)
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
@@ -615,14 +666,49 @@ func TestMakeRequestHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "Error making an HTTP request to Nexpose with URL http://localhost/api/3/sites/siteID/assets?page=100&size=100:")
 }
 
+func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRT := NewMockRoundTripper(ctrl)
+	resp := SiteAssetsResponse{
+		Resources: []Asset{Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Page:      Page{},
+		Links:     Link{},
+	}
+	respJSON, _ := json.Marshal(resp)
+	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
+		Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
+		StatusCode: http.StatusOK,
+	}, nil)
+
+	assetFetcher := &NexposeAssetFetcher{
+		HTTPClient: &http.Client{Transport: mockRT},
+		Host:       "http://localhost",
+		PageSize:   100,
+	}
+
+	var wg sync.WaitGroup
+	assetChan := make(chan domain.AssetEvent, 1)
+	errChan := make(chan error, 1)
+
+	wg.Add(1)
+	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	wg.Wait()
+
+	close(assetChan)
+	close(errChan)
+
+	assert.IsType(t, &ErrorConvertingAssetPayload{}, <-errChan)
+}
+
 func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 	resp := SiteAssetsResponse{
-		Resources: []domain.Asset{},
+		Resources: []Asset{},
 		Page:      Page{},
-		Links:     domain.Link{},
+		Links:     Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -636,7 +722,7 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	assetChan := make(chan domain.Asset, 1)
+	assetChan := make(chan domain.AssetEvent, 1)
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
@@ -646,7 +732,7 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	close(assetChan)
 	close(errChan)
 
-	assert.Equal(t, domain.Asset{}, <-assetChan) // An empty asset will be added to assetChan if there's a response with no asset
+	assert.Equal(t, domain.AssetEvent{}, <-assetChan) // An empty asset will be added to assetChan if there's a response with no asset
 	assert.Nil(t, <-errChan)
 }
 
@@ -665,7 +751,7 @@ func TestMakeRequestWithNoResponse(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	assetChan := make(chan domain.Asset, 1)
+	assetChan := make(chan domain.AssetEvent, 1)
 	errChan := make(chan error, 1)
 	defer close(assetChan)
 	defer close(errChan)

--- a/pkg/domain/assetFetcher.go
+++ b/pkg/domain/assetFetcher.go
@@ -6,5 +6,5 @@ import (
 
 // AssetFetcher represents the interface you can use to fetch scanned assets for a given site
 type AssetFetcher interface {
-	FetchAssets(ctx context.Context, siteID string) (<-chan Asset, <-chan error)
+	FetchAssets(ctx context.Context, siteID string) (<-chan AssetEvent, <-chan error)
 }

--- a/pkg/domain/asset_event.go
+++ b/pkg/domain/asset_event.go
@@ -1,0 +1,15 @@
+package domain
+
+import "time"
+
+// AssetEvent contains all pertinent Nexpose Asset information for downstream services
+type AssetEvent struct {
+	// The last time this asset was scanned.
+	LastScanned time.Time
+	// The primary host name (local or FQDN) of the asset.
+	Hostname string
+	// The identifier of the asset.
+	ID int64
+	// The primary IPv4 or IPv6 address of the asset.
+	IP string
+}

--- a/pkg/handlers/v1/mock_http_test.go
+++ b/pkg/handlers/v1/mock_http_test.go
@@ -5,10 +5,11 @@
 package v1
 
 import (
-context "context"
-domain "github.com/asecurityteam/nexpose-vuln-notifier/pkg/domain"
-gomock "github.com/golang/mock/gomock"
-reflect "reflect"
+	context "context"
+	reflect "reflect"
+
+	domain "github.com/asecurityteam/nexpose-vuln-notifier/pkg/domain"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockAssetFetcher is a mock of AssetFetcher interface
@@ -35,9 +36,9 @@ func (m *MockAssetFetcher) EXPECT() *MockAssetFetcherMockRecorder {
 }
 
 // FetchAssets mocks base method
-func (m *MockAssetFetcher) FetchAssets(arg0 context.Context, arg1 string) (<-chan domain.Asset, <-chan error) {
+func (m *MockAssetFetcher) FetchAssets(arg0 context.Context, arg1 string) (<-chan domain.AssetEvent, <-chan error) {
 	ret := m.ctrl.Call(m, "FetchAssets", arg0, arg1)
-	ret0, _ := ret[0].(<-chan domain.Asset)
+	ret0, _ := ret[0].(<-chan domain.AssetEvent)
 	ret1, _ := ret[1].(<-chan error)
 	return ret0, ret1
 }

--- a/pkg/handlers/v1/nexposevulnnotifier_test.go
+++ b/pkg/handlers/v1/nexposevulnnotifier_test.go
@@ -17,10 +17,10 @@ func TestNexposeVulnNotificationHandler(t *testing.T) {
 
 	assetFetcher := NewMockAssetFetcher(mockCtrl)
 
-	assetChan := make(chan domain.Asset)
+	assetChan := make(chan domain.AssetEvent)
 	errChan := make(chan error)
 
-	asset := domain.Asset{
+	asset := domain.AssetEvent{
 		ID: 12345,
 	}
 


### PR DESCRIPTION
* Move `Asset` to `assetfetcher` package as it is only used for JSON unmarshalling
* Create `AssetEvent` that contains only the information we care about
* Only include the timestamp of the latest scan
* Add `File` for handling the Nexpose API response (prev os.File)