### PR TITLE
Add settings library to read in and use environment variables

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,13 +24,11 @@ services:
       - SERVERFULL_RUNTIME_STATS_DATADOG_ADDRESS=statsd:8126
       - SERVERFULL_RUNTIME_SIGNALS_INSTALLED=OS
       - SERVERFULL_RUNTIME_SIGNALS_OS_SIGNALS=15 2
-      ## Nexpose and producer configuration can be set here. Sensitive information
-      ## should be set through environment variables and are just here for documentation purposes
-      - NEXPOSE_HOST=http://localhost
-      - NEXPOSE_USERNAME=username
-      - NEXPOSE_PASSWORD=password
-      - NEXPOSE_ASSETFETCHERPAGESIZE=100
-      - PRODUCER_ENDPOINT=http://localhost
+      - NEXPOSE_HOST
+      - NEXPOSE_USERNAME
+      - NEXPOSE_PASSWORD
+      - NEXPOSE_ASSETFETCHERPAGESIZE
+      - PRODUCER_ENDPOINT
   gateway:
     build:
       context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,13 @@ services:
       - SERVERFULL_RUNTIME_STATS_DATADOG_ADDRESS=statsd:8126
       - SERVERFULL_RUNTIME_SIGNALS_INSTALLED=OS
       - SERVERFULL_RUNTIME_SIGNALS_OS_SIGNALS=15 2
-      - NEXPOSE_SITE_ASSET_PAGE_SIZE=100
+      ## Nexpose and producer configuration can be set here. Sensitive information
+      ## should be set through environment variables and are just here for documentation purposes
+      - NEXPOSE_HOST=http://localhost
+      - NEXPOSE_USERNAME=username
+      - NEXPOSE_PASSWORD=password
+      - NEXPOSE_ASSETFETCHERPAGESIZE=100
+      - PRODUCER_ENDPOINT=http://localhost
   gateway:
     build:
       context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - NEXPOSE_HOST
       - NEXPOSE_USERNAME
       - NEXPOSE_PASSWORD
-      - NEXPOSE_ASSETFETCHERPAGESIZE
+      - NEXPOSE_PAGESIZE
       - PRODUCER_ENDPOINT
   gateway:
     build:

--- a/main.go
+++ b/main.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/assetfetcher"
-	nexposevulnnotiifier "github.com/asecurityteam/nexpose-vuln-notifier/pkg/handlers/v1"
+	nexposevulnnotifier "github.com/asecurityteam/nexpose-vuln-notifier/pkg/handlers/v1"
 	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/producer"
 	"github.com/asecurityteam/runhttp"
-	"github.com/asecurityteam/serverfull/pkg"
+	serverfull "github.com/asecurityteam/serverfull/pkg"
 	serverfulldomain "github.com/asecurityteam/serverfull/pkg/domain"
 	"github.com/asecurityteam/settings"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -36,7 +36,7 @@ func main() {
 	}
 	assetProducer.HTTPClient = http.DefaultClient
 
-	notifier := &nexposevulnnotiifier.NexposeVulnNotificationHandler{
+	notifier := &nexposevulnnotifier.NexposeVulnNotificationHandler{
 		Producer:     assetProducer,
 		AssetFetcher: assetFetcher,
 		LogFn:        runhttp.LoggerFromContext,

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/assetfetcher"
 	nexposevulnnotiifier "github.com/asecurityteam/nexpose-vuln-notifier/pkg/handlers/v1"
@@ -19,29 +18,33 @@ import (
 func main() {
 	ctx := context.Background()
 
-	pageSize, _ := strconv.Atoi(os.Getenv("NEXPOSE_SITE_ASSET_PAGE_SIZE"))
+	source, err := settings.NewEnvSource(os.Environ())
+	if err != nil {
+		panic(err.Error())
+	}
+	assetFetcherComponent := &assetfetcher.AssetFetcherConfigComponent{}
+	assetFetcher := new(assetfetcher.NexposeAssetFetcher)
+	if err = settings.NewComponent(context.Background(), source, assetFetcherComponent, assetFetcher); err != nil {
+		panic(err.Error())
+	}
+	assetFetcher.HTTPClient = http.DefaultClient
+
+	producerComponent := &producer.ProducerConfigComponent{}
+	assetProducer := new(producer.AssetProducer)
+	if err = settings.NewComponent(context.Background(), source, producerComponent, assetProducer); err != nil {
+		panic(err.Error())
+	}
+	assetProducer.HTTPClient = http.DefaultClient
 
 	notifier := &nexposevulnnotiifier.NexposeVulnNotificationHandler{
-		Producer: &producer.AssetProducer{
-			HTTPClient: http.DefaultClient,
-			Endpoint:   os.Getenv("STREAMING_APPLIANCE_ENDPOINT"),
-		},
-		AssetFetcher: &assetfetcher.NexposeAssetFetcher{
-			HTTPClient: http.DefaultClient,
-			Host:       os.Getenv("NEXPOSE_HOST"),
-			PageSize:   pageSize,
-		},
-		LogFn:  runhttp.LoggerFromContext,
-		StatFn: runhttp.StatFromContext,
+		Producer:     assetProducer,
+		AssetFetcher: assetFetcher,
+		LogFn:        runhttp.LoggerFromContext,
+		StatFn:       runhttp.StatFromContext,
 	}
 
 	lambdaHandlers := map[string]serverfulldomain.Handler{
 		"notification": lambda.NewHandler(notifier.Handle),
-	}
-
-	source, err := settings.NewEnvSource(os.Environ())
-	if err != nil {
-		panic(err.Error())
 	}
 
 	rt, err := serverfull.NewStatic(ctx, source, lambdaHandlers)

--- a/pkg/assetfetcher/config.go
+++ b/pkg/assetfetcher/config.go
@@ -1,0 +1,35 @@
+package assetfetcher
+
+import "context"
+
+// AssetFetcherConfig holds configuration to connect to Nexpose
+// and make a call to the fetch assets API
+type AssetFetcherConfig struct {
+	Host                 string
+	Username             string
+	Password             string
+	AssetFetcherPageSize int
+}
+
+// Name is used by the settings library and will add a "NEXPOSE_"
+// prefix to AssetFetcherConfig environment variables
+func (c *AssetFetcherConfig) Name() string {
+	return "Nexpose"
+}
+
+// AssetFetcherConfigComponent satisfies the settings library Component
+// API, and may be used by the settings.NewComponent function.
+type AssetFetcherConfigComponent struct{}
+
+// Settings can be used to populate default values if there are any
+func (*AssetFetcherConfigComponent) Settings() *AssetFetcherConfig { return &AssetFetcherConfig{} }
+
+// New constructs a NexposeAssetFetcher from a config.
+func (*AssetFetcherConfigComponent) New(_ context.Context, c *AssetFetcherConfig) (*NexposeAssetFetcher, error) {
+	return &NexposeAssetFetcher{
+		Host:     c.Host,
+		Username: c.Username,
+		Password: c.Password,
+		PageSize: c.AssetFetcherPageSize,
+	}, nil
+}

--- a/pkg/assetfetcher/config.go
+++ b/pkg/assetfetcher/config.go
@@ -1,14 +1,17 @@
 package assetfetcher
 
-import "context"
+import (
+	"context"
+	"net/url"
+)
 
 // AssetFetcherConfig holds configuration to connect to Nexpose
 // and make a call to the fetch assets API
 type AssetFetcherConfig struct {
-	Host                 string
-	Username             string
-	Password             string
-	AssetFetcherPageSize int
+	Host     string `description:"The scheme and host of a Nexpose instance."`
+	Username string `description:"The username used to login to the Nexpose instance at the given host."`
+	Password string `description:"The password for the corresponding username."`
+	PageSize int    `description:"The number of assets that should be returned from the Nexpose API at one time."`
 }
 
 // Name is used by the settings library and will add a "NEXPOSE_"
@@ -22,14 +25,23 @@ func (c *AssetFetcherConfig) Name() string {
 type AssetFetcherConfigComponent struct{}
 
 // Settings can be used to populate default values if there are any
-func (*AssetFetcherConfigComponent) Settings() *AssetFetcherConfig { return &AssetFetcherConfig{} }
+func (*AssetFetcherConfigComponent) Settings() *AssetFetcherConfig {
+	return &AssetFetcherConfig{
+		PageSize: 100,
+	}
+}
 
 // New constructs a NexposeAssetFetcher from a config.
 func (*AssetFetcherConfigComponent) New(_ context.Context, c *AssetFetcherConfig) (*NexposeAssetFetcher, error) {
+	host, err := url.Parse(c.Host)
+	if err != nil {
+		return nil, err
+	}
+
 	return &NexposeAssetFetcher{
-		Host:     c.Host,
+		Host:     host,
 		Username: c.Username,
 		Password: c.Password,
-		PageSize: c.AssetFetcherPageSize,
+		PageSize: c.PageSize,
 	}, nil
 }

--- a/pkg/assetfetcher/config_test.go
+++ b/pkg/assetfetcher/config_test.go
@@ -1,6 +1,7 @@
 package assetfetcher
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,4 +10,38 @@ import (
 func TestName(t *testing.T) {
 	assetFetcherConfig := AssetFetcherConfig{}
 	assert.Equal(t, "Nexpose", assetFetcherConfig.Name())
+}
+
+func TestAssetComponentDefaultConfig(t *testing.T) {
+	component := &AssetFetcherConfigComponent{}
+	config := component.Settings()
+	assert.Empty(t, config.Host)
+	assert.Empty(t, config.Username)
+	assert.Empty(t, config.Password)
+	assert.Equal(t, config.PageSize, 100)
+}
+
+func TestAssetFetcherConfigWithValues(t *testing.T) {
+	assetFetcherComponent := AssetFetcherConfigComponent{}
+	config := &AssetFetcherConfig{
+		Host:     "http://localhost",
+		Username: "myusername",
+		Password: "mypassword",
+		PageSize: 5,
+	}
+	assetFetcher, err := assetFetcherComponent.New(context.Background(), config)
+
+	assert.Equal(t, "http://localhost", assetFetcher.Host.String())
+	assert.Equal(t, "myusername", assetFetcher.Username)
+	assert.Equal(t, "mypassword", assetFetcher.Password)
+	assert.Equal(t, 5, assetFetcher.PageSize)
+	assert.Nil(t, err)
+}
+
+func TestAssetFetcherConfigWithInvalidHost(t *testing.T) {
+	assetFetcherComponent := AssetFetcherConfigComponent{}
+	config := &AssetFetcherConfig{Host: "~!@#$%^&*()_+:?><!@#$%^&*())_:"}
+	_, err := assetFetcherComponent.New(context.Background(), config)
+
+	assert.Error(t, err)
 }

--- a/pkg/assetfetcher/config_test.go
+++ b/pkg/assetfetcher/config_test.go
@@ -1,0 +1,12 @@
+package assetfetcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName(t *testing.T) {
+	assetFetcherConfig := AssetFetcherConfig{}
+	assert.Equal(t, "Nexpose", assetFetcherConfig.Name())
+}

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sync"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestFetchAssetsSuccess(t *testing.T) {
 		ID: 123456,
 	}
 	resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{IP: "127.0.0.1", ID: 123456}},
+		Resources: []Asset{{IP: "127.0.0.1", ID: 123456}},
 		Page: Page{
 			TotalPages:     1,
 			TotalResources: 1,
@@ -38,9 +39,10 @@ func TestFetchAssetsSuccess(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -87,11 +89,11 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 		TotalResources: 2,
 	}
 	resp1 := SiteAssetsResponse{
-		Resources: []Asset{Asset{IP: "127.0.0.1", ID: 123}},
+		Resources: []Asset{{IP: "127.0.0.1", ID: 123}},
 		Page:      page,
 	}
 	resp2 := SiteAssetsResponse{
-		Resources: []Asset{Asset{IP: "127.0.0.2", ID: 456}},
+		Resources: []Asset{{IP: "127.0.0.2", ID: 456}},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(resp1)
@@ -106,9 +108,10 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   1,
 	}
 
@@ -153,15 +156,15 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
 		TotalResources: 5,
 	}
 	page1Resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{ID: 1}, Asset{ID: 2}},
+		Resources: []Asset{{ID: 1}, {ID: 2}},
 		Page:      page,
 	}
 	page2Resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{ID: 3}, Asset{ID: 4}},
+		Resources: []Asset{{ID: 3}, {ID: 4}},
 		Page:      page,
 	}
 	page3Resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{ID: 5}},
+		Resources: []Asset{{ID: 5}},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(page1Resp)
@@ -181,9 +184,10 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   2, // with a page size of 2: 2 assets will be returned for pages 1 and 2, and 1 will be returned on page 3
 	}
 
@@ -231,11 +235,11 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalledWithError(t *testing.T)
 		TotalResources: 5,
 	}
 	page1Resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{ID: 1}, Asset{ID: 2}},
+		Resources: []Asset{{ID: 1}, {ID: 2}},
 		Page:      page,
 	}
 	page3Resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{ID: 3}},
+		Resources: []Asset{{ID: 3}},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(page1Resp)
@@ -253,9 +257,10 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalledWithError(t *testing.T)
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   2,
 	}
 
@@ -300,9 +305,10 @@ func TestFetchAssetsBadJSONInResponseError(t *testing.T) {
 		Body: ioutil.NopCloser(bytes.NewReader([]byte("fail"))),
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 	}
 
 	_, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -328,9 +334,10 @@ func TestFetchAssetsWithErrorReadingResponse(t *testing.T) {
 		Body: ioutil.NopCloser(rd),
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -380,9 +387,10 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -398,9 +406,10 @@ func TestFetchAssetsHTTPError(t *testing.T) {
 
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("HTTPError"))
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -436,7 +445,7 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 	mockRT := NewMockRoundTripper(ctrl)
 
 	resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
 		Page: Page{
 			TotalPages:     1,
 			TotalResources: 1,
@@ -449,9 +458,10 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
+	host, _ := url.Parse("http://localhost")
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   1,
 	}
 
@@ -481,57 +491,6 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 	assert.IsType(t, &ErrorConvertingAssetPayload{}, actualError)
 }
 
-func TestFetchAssetsWithInvalidHost(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockRT := NewMockRoundTripper(ctrl)
-	asset := Asset{
-		IP: "127.0.0.1",
-		ID: 123456,
-	}
-	resp := SiteAssetsResponse{
-		Resources: []Asset{asset},
-		Page:      Page{},
-		Links:     Link{},
-	}
-	respJSON, _ := json.Marshal(resp)
-	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
-		StatusCode: http.StatusOK,
-	}, nil).Times(0)
-
-	nexposeAssetFetcher := &NexposeAssetFetcher{
-		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "~!@#$%^&*()_+:?><!@#$%^&*())_:",
-		PageSize:   100,
-	}
-
-	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
-
-	var actualError error
-
-	for {
-		select {
-		case respAsset, ok := <-assetChan:
-			if !ok {
-				assetChan = nil
-			} else {
-				t.Fatalf("Unexpected error occurred %v ", respAsset)
-			}
-		case err, ok := <-errChan:
-			if !ok {
-				errChan = nil
-			} else {
-				actualError = err
-			}
-		}
-		if assetChan == nil && errChan == nil {
-			break
-		}
-	}
-	assert.IsType(t, &URLParsingError{}, actualError)
-}
-
 func TestMakeRequestSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -553,9 +512,10 @@ func TestMakeRequestSuccess(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
-	assetFetcher := &NexposeAssetFetcher{
+	host, _ := url.Parse("http://localhost")
+	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -566,7 +526,7 @@ func TestMakeRequestSuccess(t *testing.T) {
 	defer close(errChan)
 
 	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	nexposeAssetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
 
 	assert.NotNil(t, <-assetChan)
 }
@@ -582,9 +542,10 @@ func TestMakeRequestWithErrorReadingResponse(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
-	assetFetcher := &NexposeAssetFetcher{
+	host, _ := url.Parse("http://localhost")
+	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -593,48 +554,13 @@ func TestMakeRequestWithErrorReadingResponse(t *testing.T) {
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	nexposeAssetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
 	wg.Wait()
 
 	close(assetChan)
 	close(errChan)
 
 	assert.IsType(t, &ErrorReadingNexposeResponse{}, <-errChan)
-}
-
-func TestMakeRequestWithInvalidHost(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockRT := NewMockRoundTripper(ctrl)
-	resp := SiteAssetsResponse{
-		Resources: []Asset{},
-		Page:      Page{},
-		Links:     Link{},
-	}
-	respJSON, _ := json.Marshal(resp)
-	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
-		StatusCode: http.StatusOK,
-	}, nil).Times(0)
-
-	assetFetcher := &NexposeAssetFetcher{
-		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "~!@#$%^&*()_+:?><!@#$%^&*())_:",
-		PageSize:   100,
-	}
-
-	var wg sync.WaitGroup
-	assetChan := make(chan domain.AssetEvent, 1)
-	errChan := make(chan error, 1)
-
-	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
-	wg.Wait()
-
-	close(assetChan)
-	close(errChan)
-
-	assert.IsType(t, &URLParsingError{}, <-errChan)
 }
 
 func TestMakeRequestHTTPError(t *testing.T) {
@@ -644,9 +570,10 @@ func TestMakeRequestHTTPError(t *testing.T) {
 
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("HTTPError"))
 
-	assetFetcher := &NexposeAssetFetcher{
+	host, _ := url.Parse("http://localhost")
+	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -655,7 +582,7 @@ func TestMakeRequestHTTPError(t *testing.T) {
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	nexposeAssetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
 	wg.Wait()
 
 	close(assetChan)
@@ -671,7 +598,7 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 	resp := SiteAssetsResponse{
-		Resources: []Asset{Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
 		Page:      Page{},
 		Links:     Link{},
 	}
@@ -681,9 +608,10 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 		StatusCode: http.StatusOK,
 	}, nil)
 
-	assetFetcher := &NexposeAssetFetcher{
+	host, _ := url.Parse("http://localhost")
+	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -692,7 +620,7 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	nexposeAssetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
 	wg.Wait()
 
 	close(assetChan)
@@ -715,9 +643,11 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewReader(respJSON)),
 		StatusCode: http.StatusOK,
 	}, nil)
-	assetFetcher := &NexposeAssetFetcher{
+
+	host, _ := url.Parse("http://localhost")
+	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 		PageSize:   100,
 	}
 
@@ -726,7 +656,7 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	errChan := make(chan error, 1)
 
 	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	nexposeAssetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
 	wg.Wait()
 
 	close(assetChan)
@@ -745,9 +675,10 @@ func TestMakeRequestWithNoResponse(t *testing.T) {
 		Body: ioutil.NopCloser(bytes.NewReader([]byte("fail"))),
 	}, nil)
 
-	assetFetcher := &NexposeAssetFetcher{
+	host, _ := url.Parse("http://localhost")
+	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Host:       "http://localhost",
+		Host:       host,
 	}
 
 	var wg sync.WaitGroup
@@ -757,45 +688,33 @@ func TestMakeRequestWithNoResponse(t *testing.T) {
 	defer close(errChan)
 
 	wg.Add(1)
-	assetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
+	nexposeAssetFetcher.makeRequest(context.Background(), &wg, "siteID", 100, assetChan, errChan)
 
 	assert.IsType(t, &ErrorParsingJSONResponse{}, <-errChan) // Error will be returned from json.Unmarshal and added to errChan
 }
 
 func TestNewNexposeSiteAssetsRequestSuccess(t *testing.T) {
+	host, _ := url.Parse("http://localhost")
 	assetFetcher := &NexposeAssetFetcher{
-		Host:     "http://localhost",
+		Host:     host,
 		Username: "username",
 		Password: "password",
 		PageSize: 100,
 	}
-	req, err := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
+	req := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
 
-	assert.Nil(t, err)
 	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
 }
 
 func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
+	host, _ := url.Parse("http://localhost")
 	assetFetcher := &NexposeAssetFetcher{
-		Host:     "http://localhost",
+		Host:     host,
 		Username: "username",
 		Password: "password",
 		PageSize: 100,
 	}
-	req, err := assetFetcher.newNexposeSiteAssetsRequest("/siteID/", 1)
+	req := assetFetcher.newNexposeSiteAssetsRequest("/siteID/", 1)
 
-	assert.NoError(t, err)
 	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
-}
-
-func TestNewNexposeSiteAssetsRequestWithInvalidHost(t *testing.T) {
-	assetFetcher := &NexposeAssetFetcher{
-		Host:     "http://nexpose!@#$%^&*().com",
-		Username: "username",
-		Password: "password",
-		PageSize: 100,
-	}
-	_, err := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
-
-	assert.IsType(t, &URLParsingError{}, err) // Error will be returned from url.Parse
 }

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -763,21 +763,39 @@ func TestMakeRequestWithNoResponse(t *testing.T) {
 }
 
 func TestNewNexposeSiteAssetsRequestSuccess(t *testing.T) {
-	req, err := newNexposeSiteAssetsRequest("http://nexpose-instance.com", "siteID", 1, 100)
+	assetFetcher := &NexposeAssetFetcher{
+		Host:     "http://localhost",
+		Username: "username",
+		Password: "password",
+		PageSize: 100,
+	}
+	req, err := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "http://nexpose-instance.com/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
+	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
 }
 
 func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
-	req, err := newNexposeSiteAssetsRequest("http://nexpose-instance.com/", "/siteID/", 1, 100)
+	assetFetcher := &NexposeAssetFetcher{
+		Host:     "http://localhost",
+		Username: "username",
+		Password: "password",
+		PageSize: 100,
+	}
+	req, err := assetFetcher.newNexposeSiteAssetsRequest("/siteID/", 1)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "http://nexpose-instance.com/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
+	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
 }
 
 func TestNewNexposeSiteAssetsRequestWithInvalidHost(t *testing.T) {
-	_, err := newNexposeSiteAssetsRequest("http://nexpose!@#$%^&*().com", "siteID", 1, 100)
+	assetFetcher := &NexposeAssetFetcher{
+		Host:     "http://nexpose!@#$%^&*().com",
+		Username: "username",
+		Password: "password",
+		PageSize: 100,
+	}
+	_, err := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
 
 	assert.IsType(t, &URLParsingError{}, err) // Error will be returned from url.Parse
 }

--- a/pkg/producer/config.go
+++ b/pkg/producer/config.go
@@ -1,0 +1,27 @@
+package producer
+
+import "context"
+
+// ProducerConfig holds configuration required to send Nexpose assets
+// to a queue via an HTTP Producer
+type ProducerConfig struct {
+	Endpoint string
+}
+
+// Name is used by the settings library and will add a "HTTPPRODUCER"
+// prefix to ProducerConfig environment variables
+func (c *ProducerConfig) Name() string {
+	return "HTTPProducer"
+}
+
+// ProducerConfigComponent satisfies the settings library Component
+// API, and may be used by the settings.NewComponent function.
+type ProducerConfigComponent struct{}
+
+// Settings can be used to populate default values if there are any
+func (*ProducerConfigComponent) Settings() *ProducerConfigComponent { return &ProducerConfigComponent{} }
+
+// New constructs a NexposeAssetFetcher from a config.
+func (*ProducerConfigComponent) New(_ context.Context, c *ProducerConfigComponent) (*AssetProducer, error) {
+	return &AssetProducer{}, nil
+}

--- a/pkg/producer/config_test.go
+++ b/pkg/producer/config_test.go
@@ -1,0 +1,12 @@
+package producer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName(t *testing.T) {
+	producerConfig := ProducerConfig{}
+	assert.Equal(t, "HTTPProducer", producerConfig.Name())
+}

--- a/pkg/producer/http.go
+++ b/pkg/producer/http.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-
 	"time"
 
 	"github.com/asecurityteam/nexpose-vuln-notifier/pkg/domain"


### PR DESCRIPTION
We made a library (https://github.com/asecurityteam/settings) to help
manage configuration our services might need. For the nexpose-vuln-notifier,
we need Nexpose configuration to know how to connect to the Nexpose instance
and hit the API to get Nexpose Assets, and we need Producer information to know
the endpoint we should produce the Nexpose Assets to. This change adds that
configuration.